### PR TITLE
fix small issue with volume example

### DIFF
--- a/docs/guides/volumes.md
+++ b/docs/guides/volumes.md
@@ -19,6 +19,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: test-pvc
 spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi # amount of storage to be requested
   storageClassName: symbiosis-block-storage # this line can be omitted as symbiosis-block-storage is the default CSI driver
   volumeName: test-volume
 ```

--- a/docs/guides/volumes.md
+++ b/docs/guides/volumes.md
@@ -25,7 +25,7 @@ spec:
     requests:
       storage: 1Gi # amount of storage to be requested
   storageClassName: symbiosis-block-storage # this line can be omitted as symbiosis-block-storage is the default CSI driver
-  volumeName: test-volume
+  volumeMode: Filesystem
 ```
 
 You can read more about persistent volumes and how they can be configured in the [official documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).


### PR DESCRIPTION
Fixes this issue when using the sample PVC

The PersistentVolumeClaim "test-pvc" is invalid: 
* spec.accessModes: Required value: at least 1 access mode is required
* spec.resources[storage]: Required value
